### PR TITLE
MGDCTRS-1669: update SOP related with stop / start connectors

### DIFF
--- a/observability/sops/alerts/rhoc_connectors_availability.adoc
+++ b/observability/sops/alerts/rhoc_connectors_availability.adoc
@@ -95,7 +95,6 @@ redhat-openshift-connectors-cc6ae6o7764p8lrcfbk0   mctr-cd1ur6bhl69lnuj0urn0   c
 redhat-openshift-connectors-cc6ae6o7764p8lrcfbk0   mctr-cdl60k5ajgdagid3bp00   cc6ae6o7764p8lrcfbj0   cdl60jtajgdagid3bov0   http_sink_0.1       cdl60k5ajgdagid3bp00   Monitor   failed
 ----
 
-
 . The project where the failing connector is running will have the NAMESPACE_ID attached to the name. For this case `cd71tbtakkggo7fhpgmg`
 +
 ----
@@ -127,6 +126,8 @@ map[camel.apache.org/integration:mctr-cd779jbhl69lnuj6cbc0 cos.bf2.org/connector
 ----
 
 . Identify the reason why the connector is failing by tailing the pod logs. The connector will fail if external systems can't be reached or accessed. For instance a mysql connector will fail if the mysql server is unreachable or if the provided credentials are wrong.
+
+. When the connector fails to run due to external systems, consider https://github.com/bf2fc6cc711aee1a0c2a/cos-tools/blob/main/observability/sops/howto/stop_connector.asciidoc[stopping the connector] and informing the customer.
 
 == Validate
 

--- a/observability/sops/howto/stop_connector.asciidoc
+++ b/observability/sops/howto/stop_connector.asciidoc
@@ -23,14 +23,23 @@ The purpose of this SOP is to describe the process of stopping a connector.
 1. You need the connector ID.
 2. You will need access to the relevant Fleet Shard OSD cluster and know the namespace in which the connector workload is running.
 3. You also will need access to the COS Fleet Manager instance that manages the OSD cluster.
+4. When using the rhoc-cli, you have to be part of cos-fleet-manager-admin-full-prod rover group.
 
 == Execute/Resolution
-1. Stop the desired connector by sending a patch call to the cos-fleet-manager, setting the desired_state to `stopped`:
+Stop the desired connector. This can be achieved by:
+
+1.  Sending a patch call to the cos-fleet-manager, setting the desired_state to `stopped`
 +
 ```
 ./bin/update-connector $ID '{ "desired_state": "stopped" }'
 ```
+
+2. Or by using the rhoc-cli utility
 +
+```
+./rhoc-cli connectors stop --id $ID
+```
+
 The cos-fleetshard-sync should pick the changes and apply them. It should not take longer than few seconds. If the connector doesn't stop, proceed to delete the connector Custom Resource.
 
 1. Delete the connector custom resource (only needed if previous step didn't succeed).
@@ -43,7 +52,7 @@ oc get ManagedConnectors -n $NAMESPACE | grep $ID
 oc delete ManagedConnector $MC_ID
 ```
 +
-Once the ManagedConnector is deleted, the cos-fleet-manager wull recreate it and the `PHASE` should be `stopped`
+Once the ManagedConnector is deleted, the cos-fleet-manager will recreate it and the `PHASE` should be `stopped`
 
 == Validate
 


### PR DESCRIPTION
* Consider using `rhoc-cli connectors stop` when stopping a connector.
* Include stopping connectors as posible solution when the cause of the problem is an external source.